### PR TITLE
Fix communist victory idea name typo

### DIFF
--- a/common/national_focus/playabletwr_ideology_shared.txt
+++ b/common/national_focus/playabletwr_ideology_shared.txt
@@ -140,7 +140,7 @@ shared_focus = {
   prerequisite = { focus = PTWR_communist_mobilization }
   available = { NOT = { has_war = yes } NOT = { is_subject = yes } }
   completion_reward = {
-    remove_ideas = TWR_communist_movement_spirt
+    remove_ideas = TWR_communist_movement_spirit
     remove_ideas = TWR_communist_propaganda_spirit
     remove_ideas = TWR_communist_mobilization_spirit
     add_ideas = TWR_communist_permanent_spirit


### PR DESCRIPTION
## Summary
- correct a typo in `PTWR_communist_victory` that prevented removing the communist movement spirit

## Testing
- `grep -n "movement_spirit" -R`

------
https://chatgpt.com/codex/tasks/task_b_685a79c816708320a159bd81da20859b