### PR TITLE
Add duplicate color test

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ playabletwr/
 3. Test in-game
 4. Commit and push changes
 
+## Testing
+
+This repository includes a script to check that country tags are unique in
+`common/countries/colors.txt`. Run the script with Python:
+
+```bash
+python3 tests/test_unique_colors.py
+```
+
+The command exits with a non-zero status if any tag is defined more than once.
+
 ## Version History
 
 ### v1.0.0 (Current)

--- a/tests/test_unique_colors.py
+++ b/tests/test_unique_colors.py
@@ -1,0 +1,27 @@
+import re
+import sys
+from pathlib import Path
+
+
+def main():
+    colors_path = Path(__file__).resolve().parents[1] / "common" / "countries" / "colors.txt"
+    tag_regex = re.compile(r"^([A-Z0-9]{3})\s*=\s*\{")
+    counts = {}
+
+    with colors_path.open(encoding="utf-8") as f:
+        for line in f:
+            match = tag_regex.match(line)
+            if match:
+                tag = match.group(1)
+                counts[tag] = counts.get(tag, 0) + 1
+
+    duplicates = {tag: count for tag, count in counts.items() if count > 1}
+    if duplicates:
+        for tag, count in duplicates.items():
+            print(f"Duplicate tag {tag} found {count} times", file=sys.stderr)
+        sys.exit(1)
+    print("No duplicates found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple Python test that fails on duplicate tags in common/countries/colors.txt
- document how to run the test in a new Testing section of the README

## Testing
- `python3 tests/test_unique_colors.py` *(fails: Duplicate tag MLT found 2 times, Duplicate tag SIK found 2 times)*

------
https://chatgpt.com/codex/tasks/task_b_685a79dabb4483209aa83173ff1edaeb