### PR TITLE
Enable vanilla faction creation

### DIFF
--- a/common/ideologies/01_TWR_fascistic_ideologies.txt
+++ b/common/ideologies/01_TWR_fascistic_ideologies.txt
@@ -33,7 +33,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no		
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no	
 		}
@@ -81,7 +81,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes		
 		}
 		
@@ -140,7 +140,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no		
 		}

--- a/common/ideologies/02_TWR_democratic_ideologies.txt
+++ b/common/ideologies/02_TWR_democratic_ideologies.txt
@@ -40,7 +40,7 @@ ideologies = {
 			can_only_justify_war_on_threat_country = yes
 			can_guarantee_other_ideologies = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = no
 			can_access_market = no	
 		}
@@ -99,7 +99,7 @@ ideologies = {
 			can_only_justify_war_on_threat_country = yes
 			can_guarantee_other_ideologies = yes
 			can_join_factions = no			
-			can_create_factions = no		
+                        can_create_factions = yes
 			can_create_collaboration_government = no
 			can_access_market = no	
 		}
@@ -155,7 +155,7 @@ ideologies = {
 			can_only_justify_war_on_threat_country = yes
 			can_guarantee_other_ideologies = yes
 			can_join_factions = no			
-			can_create_factions = no			
+                        can_create_factions = yes
 			can_create_collaboration_government = no
 			can_access_market = no
 		}

--- a/common/ideologies/03_TWR_communist_ideologies.txt
+++ b/common/ideologies/03_TWR_communist_ideologies.txt
@@ -38,7 +38,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no		
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no
 		}
@@ -92,7 +92,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no		
 		}
@@ -148,7 +148,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no		
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no	
 		}


### PR DESCRIPTION
## Summary
- allow players to form factions through vanilla mechanics by enabling `can_create_factions` for all ideology rules

## Testing
- `python3 tests/test_unique_colors.py`

------
https://chatgpt.com/codex/tasks/task_b_685ab3e12654832089a1832a7639856d