### PR TITLE
Add expansion focus without local icons

### DIFF
--- a/common/ai_strategy_plans/PTWR_ideologies.txt
+++ b/common/ai_strategy_plans/PTWR_ideologies.txt
@@ -1,0 +1,107 @@
+PTWR_Fascist_Generic = {
+    name = "PTWR Fascist AI"
+    desc = "Aggressive behavior for fascist nations"
+    allowed = { has_government = fascist }
+    enable = { has_government = fascist }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 50
+    }
+}
+
+PTWR_Communist_Generic = {
+    name = "PTWR Communist AI"
+    desc = "Expansionist behavior for communists"
+    allowed = { has_government = bolshevik_leninist }
+    enable = { has_government = bolshevik_leninist }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 40
+    }
+}
+
+PTWR_Democratic_Generic = {
+    name = "PTWR Democratic AI"
+    desc = "More defensive for democracies"
+    allowed = { has_government = social_democrat }
+    enable = { has_government = social_democrat }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 10
+    }
+}
+
+PTWR_Authoritarian_Generic = {
+    name = "PTWR Authoritarian AI"
+    desc = "Balanced aggression"
+    allowed = { has_government = paternal_autocrat }
+    enable = { has_government = paternal_autocrat }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 30
+    }
+}
+
+PTWR_Liberal_Generic = {
+    name = "PTWR Liberal AI"
+    desc = "Defensive stance"
+    allowed = { has_government = liberal }
+    enable = { has_government = liberal }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 15
+    }
+}
+
+PTWR_Conservative_Generic = {
+    name = "PTWR Conservative AI"
+    desc = "Cautious expansion"
+    allowed = { has_government = conservative }
+    enable = { has_government = conservative }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 20
+    }
+}
+
+PTWR_Socialist_Generic = {
+    name = "PTWR Socialist AI"
+    desc = "Supports revolutionary wars"
+    allowed = { has_government = socialist }
+    enable = { has_government = socialist }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 35
+    }
+}
+
+PTWR_Technocrat_Generic = {
+    name = "PTWR Technocrat AI"
+    desc = "Focus on research, limited wars"
+    allowed = { has_government = technocrat }
+    enable = { has_government = technocrat }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 20
+    }
+}
+
+PTWR_Monarchist_Generic = {
+    name = "PTWR Monarchist AI"
+    desc = "Moderate expansion"
+    allowed = { has_government = monarchist }
+    enable = { has_government = monarchist }
+    ai_strategy = {
+        type = conquer
+        id = DEFAULT
+        value = 25
+    }
+}

--- a/common/ideologies/01_TWR_fascistic_ideologies.txt
+++ b/common/ideologies/01_TWR_fascistic_ideologies.txt
@@ -33,7 +33,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no		
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no	
 		}
@@ -81,7 +81,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes		
 		}
 		
@@ -140,7 +140,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no		
 		}

--- a/common/ideologies/02_TWR_democratic_ideologies.txt
+++ b/common/ideologies/02_TWR_democratic_ideologies.txt
@@ -40,7 +40,7 @@ ideologies = {
 			can_only_justify_war_on_threat_country = yes
 			can_guarantee_other_ideologies = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = no
 			can_access_market = no	
 		}
@@ -99,7 +99,7 @@ ideologies = {
 			can_only_justify_war_on_threat_country = yes
 			can_guarantee_other_ideologies = yes
 			can_join_factions = no			
-			can_create_factions = no		
+                        can_create_factions = yes
 			can_create_collaboration_government = no
 			can_access_market = no	
 		}
@@ -155,7 +155,7 @@ ideologies = {
 			can_only_justify_war_on_threat_country = yes
 			can_guarantee_other_ideologies = yes
 			can_join_factions = no			
-			can_create_factions = no			
+                        can_create_factions = yes
 			can_create_collaboration_government = no
 			can_access_market = no
 		}

--- a/common/ideologies/03_TWR_communist_ideologies.txt
+++ b/common/ideologies/03_TWR_communist_ideologies.txt
@@ -38,7 +38,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no		
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no
 		}
@@ -92,7 +92,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no	
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no		
 		}
@@ -148,7 +148,7 @@ ideologies = {
 			can_send_volunteers = yes
 			can_puppet = yes
 			can_join_factions = no			
-			can_create_factions = no		
+                        can_create_factions = yes
 			can_create_collaboration_government = yes
 			can_access_market = no	
 		}

--- a/common/national_focus/PTWR_expansionism.txt
+++ b/common/national_focus/PTWR_expansionism.txt
@@ -1,0 +1,13 @@
+shared_focus = {
+  id = PTWR_expansionism
+  icon = GFX_goal_generic_major_alliance
+  x = 0
+  y = 0
+  cost = 10
+  available = { 
+    any_neighbor_country = { NOT = { has_war_with = ROOT } }
+  }
+  completion_reward = {
+    country_event = { id = TWR_expansion.1 }
+  }
+}

--- a/common/national_focus/generic.txt
+++ b/common/national_focus/generic.txt
@@ -19,4 +19,5 @@ focus_tree = {
     shared_focus = PTWR_Conservative_Path
     shared_focus = PTWR_Socialist_Path
     shared_focus = PTWR_Technocrat_Path
+    shared_focus = PTWR_expansionism
 }

--- a/events/TWR_expansion_events.txt
+++ b/events/TWR_expansion_events.txt
@@ -1,0 +1,15 @@
+# Expansionism Events
+country_event = {
+  id = TWR_expansion.1
+  is_triggered_only = yes
+  immediate = {
+    random_neighbor_country = {
+      limit = { NOT = { has_war_with = ROOT } }
+      ROOT = {
+        create_wargoal = { type = annex_everything target = THIS }
+        add_ai_strategy = { type = conquer id = THIS value = 200 }
+      }
+    }
+  }
+  option = { name = OK }
+}


### PR DESCRIPTION
## Summary
- allow factions to be formed for fascist, democratic, and communist ideologies
- create ideology-specific AI strategy plans for all nine TWR ideologies
- add a shared "Expansionism" focus which triggers a war goal event on a neighbor
- implement an event granting a war goal and AI conquer strategy
- reference TWR's generic alliance icons instead of bundling the DDS files

## Testing
- `python3 tests/test_unique_colors.py`


------
https://chatgpt.com/codex/tasks/task_b_685ab3e12654832089a1832a7639856d